### PR TITLE
Fix contract total count on dashboard

### DIFF
--- a/app/contracts/page.tsx
+++ b/app/contracts/page.tsx
@@ -11,5 +11,7 @@ export default async function ContractsPage() {
     getAllDeployments(),
   ])
 
-  return <ContractsDashboard userDeployments={userDeployments || []} allDeployments={allDeployments || []} />
+  const combinedDeployments = [...(allDeployments || []), ...(userDeployments || [])]
+
+  return <ContractsDashboard userDeployments={userDeployments || []} allDeployments={combinedDeployments} />
 }


### PR DESCRIPTION
## Summary
- merge user's deployments with global deployments for contract dashboard

## Testing
- `npx biome check app/contracts/page.tsx --colors=off`
- `npx biome check --colors=off` *(fails: Import statements could be sorted)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_686bf88faa4083228bcda5daed8ae7e3