### PR TITLE
chore: update agent model to gpt-5.4-nano

### DIFF
--- a/lib/agent-chat.ts
+++ b/lib/agent-chat.ts
@@ -49,7 +49,7 @@ export const generateAgentReply = async ({ agentId, messages, userId }: AgentCha
   const { agent, tools, systemPrompt } = await getAgentRuntime({ agentId, userId })
 
   const result = await generateText({
-    model: openai("gpt-5-mini"),
+    model: openai("gpt-5.4-nano"),
     providerOptions,
     system: systemPrompt,
     messages: await convertToModelMessages(messages),
@@ -64,7 +64,7 @@ export const streamAgentReply = async ({ agentId, messages, onFinish, userId }: 
   const { agent, tools, systemPrompt } = await getAgentRuntime({ agentId, userId })
 
   const result = streamText({
-    model: openai("gpt-5-mini"),
+    model: openai("gpt-5.4-nano"),
     providerOptions,
     system: systemPrompt,
     messages: await convertToModelMessages(messages),


### PR DESCRIPTION
## What changed

Replaces the outdated `gpt-5-mini` with `gpt-5.4-nano` in both `generateAgentReply` and `streamAgentReply` in `lib/agent-chat.ts`.

## Why

`gpt-5-mini` is a previous-generation model. `gpt-5.4-nano` is current-generation and sits at a slightly *lower* price point:

| Model | Input /1M | Output /1M |
|---|---|---|
| `gpt-5-mini` (old) | \$0.25 | \$2.00 |
| `gpt-5.4-nano` (new) | \$0.20 | \$1.25 |

## Verification

- Confirmed via the OpenAI models API that `gpt-5.4-nano` exists on the account (resolves to `gpt-5.4-nano-2026-03-17`).
- Ran the full `@ai-sdk/openai` code path (`generateText` + existing `providerOptions` with `reasoningEffort: "medium"` / `reasoningSummary: "concise"` + multi-step tool calling via `stopWhen: stepCountIs(5)`). Tool call executed and reasoning tokens were present in usage — matches how `agent-chat.ts` invokes the model.
- `bun run typecheck` passes.
- No package upgrades required; current `@ai-sdk/openai@^3.0.49` / `ai@^6.0.142` already support the model.

## Reviewer notes

Model IDs/pricing were cross-checked against the live OpenAI API, not just third-party pricing pages. `gpt-5.4-nano` is a lower capability tier than the `mini` tier; it was chosen deliberately to match the "similar price point" requirement. If richer reasoning is needed for complex Solidity flows, `gpt-5.4-mini` (\$0.75/\$4.50) is the same-tier successor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)