### PR TITLE
Return transaction evidence from deployment tool

### DIFF
--- a/lib/solidity/deployment-tool-result.test.ts
+++ b/lib/solidity/deployment-tool-result.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+
+import { formatDeploymentToolResult } from "@/lib/solidity/deployment-tool-result"
+
+describe("formatDeploymentToolResult", () => {
+  test("includes the exact transaction and contract evidence for the agent", () => {
+    const result = formatDeploymentToolResult({
+      chainId: 80_002,
+      contractAddress: "0xba0a7d6e0310807935c85ea4e0ba07a529d166c8",
+      explorerUrl: "https://amoy.polygonscan.com/address/0xba0a7d6e0310807935c85ea4e0ba07a529d166c8",
+      ipfsUrl: "https://ipfs.io/ipfs/example",
+      transactionExplorerUrl:
+        "https://amoy.polygonscan.com/tx/0xe585c158836fbbd167f0147aec1544cffe8b6ec868bf24ac9eeda0622192ef79",
+      transactionHash: "0xe585c158836fbbd167f0147aec1544cffe8b6ec868bf24ac9eeda0622192ef79",
+    })
+
+    expect(result).toContain("chain ID 80002")
+    expect(result).toContain("Contract address: 0xba0a7d6e0310807935c85ea4e0ba07a529d166c8.")
+    expect(result).toContain("Transaction hash: 0xe585c158836fbbd167f0147aec1544cffe8b6ec868bf24ac9eeda0622192ef79.")
+    expect(result).toContain(
+      "Transaction explorer URL: https://amoy.polygonscan.com/tx/0xe585c158836fbbd167f0147aec1544cffe8b6ec868bf24ac9eeda0622192ef79."
+    )
+  })
+})

--- a/lib/solidity/deployment-tool-result.ts
+++ b/lib/solidity/deployment-tool-result.ts
@@ -1,0 +1,24 @@
+import type { DeployContractResult } from "@/lib/types"
+
+type AgentDeploymentResult = Pick<
+  DeployContractResult,
+  "chainId" | "contractAddress" | "explorerUrl" | "ipfsUrl" | "transactionExplorerUrl" | "transactionHash"
+>
+
+export const formatDeploymentToolResult = ({
+  chainId,
+  contractAddress,
+  explorerUrl,
+  ipfsUrl,
+  transactionExplorerUrl,
+  transactionHash,
+}: AgentDeploymentResult): string =>
+  [
+    `Contract deployed on chain ID ${chainId}.`,
+    `Contract address: ${contractAddress}.`,
+    `Contract explorer URL: ${explorerUrl}.`,
+    `Transaction hash: ${transactionHash}.`,
+    `Transaction explorer URL: ${transactionExplorerUrl}.`,
+    `IPFS repository: ${ipfsUrl}.`,
+    "Verification queued for explorer verification.",
+  ].join(" ")

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import { resolveAddress, resolveDomain } from "@/lib/actions/unstoppable-domains"
 import { PRODUCTION_URL } from "@/lib/config"
 import { deployContract } from "@/lib/solidity/deploy"
+import { formatDeploymentToolResult } from "@/lib/solidity/deployment-tool-result"
 import type { ToolName } from "@/lib/types"
 
 // Re-export type for convenience
@@ -116,7 +117,7 @@ const createToolDefinitions = (context: ToolContext = {}) => ({
         contractName,
         sourceCode,
       })
-      return `Contract deployed: ${deployResult.explorerUrl} IPFS repository: ${deployResult.ipfsUrl} Verification queued for explorer verification.`
+      return formatDeploymentToolResult(deployResult)
     },
     inputSchema: schemas.deployContract,
   }),


### PR DESCRIPTION
## Summary

- return the exact chain ID, contract address, transaction hash, and explorer URLs to the agent after a deployment
- keep the IPFS and verification status in the tool result
- cover the agent-facing evidence string with a Bun test

## Why

A fresh Polygon Amoy SDK smoke deployed successfully, but the agent response could not include the transaction hash because the deployment tool formatted only the contract explorer URL and IPFS URL.

## Verification

- `bun test` — 14 passing
- `bun run typecheck`
- Biome check on changed files
- Successful Amoy receipt: https://amoy.polygonscan.com/tx/0xe585c158836fbbd167f0147aec1544cffe8b6ec868bf24ac9eeda0622192ef79